### PR TITLE
feat: auth-signup-api 구현

### DIFF
--- a/src/modules/auth/controller.js
+++ b/src/modules/auth/controller.js
@@ -1,0 +1,17 @@
+class AuthController {
+  constructor(authService) {
+    this.authService = authService;
+  }
+
+  signup = async (req, res, next) => {
+    try {
+      const { email, password, nickname } = req.body;
+      const newUser = await this.authService.createUser({ email, password, nickname });
+      return res.status(201).json({ newUser });
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+export default AuthController;

--- a/src/modules/auth/repository.js
+++ b/src/modules/auth/repository.js
@@ -1,0 +1,23 @@
+import { prisma } from '../../common/utils/prisma.js';
+
+class AuthRepository {
+  findUserByEmail = async (email) => {
+    const existingEmail = await prisma.user.findUnique({
+      where: {
+        email: email,
+      },
+    });
+
+    return existingEmail;
+  };
+
+  createUser = async (userData) => {
+    const newUser = await prisma.user.create({
+      data: userData,
+    });
+
+    return newUser;
+  };
+}
+
+export default AuthRepository;

--- a/src/modules/auth/routes.js
+++ b/src/modules/auth/routes.js
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import AuthController from './controller.js';
+import AuthService from './service.js';
+import AuthRepository from './repository.js';
+import { validate } from '../../common/middleware/validate.js';
+import { signupSchema } from './schema/signupSchema.js';
+
+const authRouter = Router();
+
+const authRepository = new AuthRepository();
+const authService = new AuthService(authRepository);
+const authController = new AuthController(authService);
+
+authRouter.post('/signup', validate(signupSchema, 'body'), authController.signup);
+export default authRouter;

--- a/src/modules/auth/schema/signupSchema.js
+++ b/src/modules/auth/schema/signupSchema.js
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const signupSchema = z
+  .object({
+    email: z
+      .string()
+      .min(1, { message: '이메일은 필수 입력 항목입니다.' })
+      .email({ message: '유효한 이메일 형식이 아닙니다.' }),
+    password: z
+      .string()
+      .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+      .regex(/[A-Za-z]/, {
+        message: '비밀번호는 최소 1개 이상의 영문자를 포함해야 합니다.',
+      })
+      .regex(/[0-9]/, {
+        message: '비밀번호는 최소 1개 이상의 숫자를 포함해야 합니다.',
+      })
+      .regex(/[^A-Za-z0-9]/, {
+        message: '비밀번호는 최소 1개 이상의 특수문자를 포함해야 합니다.',
+      }),
+    confirmPassword: z.string().min(1, { message: '비밀번호 확인은 필수 입력 항목입니다.' }),
+    nickname: z
+      .string()
+      .min(2, { message: '닉네임은 최소 2자 이상이어야 합니다.' })
+      .max(10, { message: '닉네임은 최대 10자까지 가능합니다.' }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: '비밀번호와 비밀번호 확인이 일치하지 않습니다.',
+    path: ['confirmPassword'],
+  });

--- a/src/modules/auth/service.js
+++ b/src/modules/auth/service.js
@@ -1,0 +1,29 @@
+import bcrypt from 'bcryptjs';
+
+class AuthService {
+  constructor(authRepository) {
+    this.authRepository = authRepository;
+  }
+
+  createUser = async ({ email, password, nickname }) => {
+    const existingUser = await this.authRepository.findUserByEmail(email);
+    if (existingUser) {
+      const error = new Error('이미 등록된 이메일 주소 입니다.');
+      error.statusCode = 409;
+      throw error;
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 14);
+
+    const newUser = await this.authRepository.createUser({
+      email,
+      password: hashedPassword,
+      nickname,
+    });
+
+    const { password: _, ...userWithoutPassword } = newUser;
+    return userWithoutPassword;
+  };
+}
+
+export default AuthService;

--- a/test.http
+++ b/test.http
@@ -1,0 +1,10 @@
+### 회원가입
+POST http://localhost:4000/auth/signup
+Content-Type: application/json 
+
+{
+    "email": "test33@example.com",
+    "password": "Test123@#",
+    "confirmPassword": "Test123@#",
+    "nickname" : "test12"
+}


### PR DESCRIPTION
## 작업 개요
- 회원가입 기능 구현

## 작업 상세
- 회원가입 요청 처리 (POST /auth/signup)
- 유저 정보 유효성 검증
- 비밀번호 암호화 (bcrypt)
- 이메일 중복 검사
- prisma를 통한 DB 저장

## 테스트 방법
- Postman으로 signup 요청 테스트
- 유효한 요청 시 201 응답 확인
- 중복 이메일 시 에러 반환 확인