### PR TITLE
feat: auth-login-api 구현

### DIFF
--- a/src/common/utils/jwt.js
+++ b/src/common/utils/jwt.js
@@ -1,0 +1,11 @@
+import jwt from 'jsonwebtoken';
+
+export const generateToken = (user, type) => {
+  const payload = type === 'refresh' ? { id: user.id } : { id: user.id, nickname: user.nickname };
+  const options = { expiresIn: type === 'refresh' ? '1w' : '1h' };
+  return jwt.sign(payload, process.env.JWT_SECRET, options);
+};
+
+export const verifyToken = (token) => {
+  return jwt.verify(token, process.env.JWT_SECRET);
+};

--- a/src/modules/auth/controller.js
+++ b/src/modules/auth/controller.js
@@ -7,7 +7,35 @@ class AuthController {
     try {
       const { email, password, nickname } = req.body;
       const newUser = await this.authService.createUser({ email, password, nickname });
-      return res.status(201).json({ newUser });
+      return res.status(201).json(newUser);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  login = async (req, res, next) => {
+    try {
+      const { email, password } = req.body;
+      const { user, accessToken, refreshToken } = await this.authService.login({ email, password });
+
+      // TODO: 배포 전 sameSite 설정을 'lax'로 변경
+      res.cookie('accessToken', accessToken, {
+        path: '/',
+        httpOnly: true,
+        maxAge: 60 * 60 * 1000,
+        sameSite: 'none',
+        secure: true,
+      });
+
+      res.cookie('refreshToken', refreshToken, {
+        path: '/auth/refresh',
+        httpOnly: true,
+        maxAge: 7 * 24 * 60 * 60 * 1000,
+        sameSite: 'none',
+        secure: true,
+      });
+
+      return res.status(200).json(user);
     } catch (error) {
       next(error);
     }

--- a/src/modules/auth/routes.js
+++ b/src/modules/auth/routes.js
@@ -4,7 +4,7 @@ import AuthService from './service.js';
 import AuthRepository from './repository.js';
 import { validate } from '../../common/middleware/validate.js';
 import { signupSchema } from './schema/signupSchema.js';
-
+import { loginSchema } from './schema/loginSchema.js';
 const authRouter = Router();
 
 const authRepository = new AuthRepository();
@@ -12,4 +12,6 @@ const authService = new AuthService(authRepository);
 const authController = new AuthController(authService);
 
 authRouter.post('/signup', validate(signupSchema, 'body'), authController.signup);
+authRouter.post('/login', validate(loginSchema, 'body'), authController.login);
+
 export default authRouter;

--- a/src/modules/auth/schema/loginSchema.js
+++ b/src/modules/auth/schema/loginSchema.js
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .min(1, { message: '이메일은 필수 입력 항목입니다.' })
+    .email({ message: '유효한 이메일 형식이 아닙니다.' }),
+  password: z.string().min(1, { message: '비밀번호는 필수 입력 항목입니다.' }),
+});

--- a/src/modules/auth/service.js
+++ b/src/modules/auth/service.js
@@ -1,4 +1,5 @@
 import bcrypt from 'bcryptjs';
+import { generateToken } from '../../common/utils/jwt.js';
 
 class AuthService {
   constructor(authRepository) {
@@ -23,6 +24,34 @@ class AuthService {
 
     const { password: _, ...userWithoutPassword } = newUser;
     return userWithoutPassword;
+  };
+
+  login = async ({ email, password: passwordInput }) => {
+    const existingUser = await this.authRepository.findUserByEmail(email);
+    if (!existingUser) {
+      const error = new Error('등록되지 않은 이메일 주소 입니다.');
+      error.statusCode = 404;
+      throw error;
+    }
+
+    const { password: storedPassword } = existingUser;
+    const isMatch = await bcrypt.compare(passwordInput, storedPassword);
+    if (!isMatch) {
+      const error = new Error('비밀번호가 일치하지 않습니다.');
+      error.statusCode = 401;
+      throw error;
+    }
+
+    const user = {
+      id: existingUser.id,
+      nickname: existingUser.nickname,
+      points: existingUser.points,
+    };
+
+    const accessToken = generateToken(user, 'access');
+    const refreshToken = generateToken(user, 'refresh');
+
+    return { user, accessToken, refreshToken };
   };
 }
 

--- a/test.http
+++ b/test.http
@@ -1,5 +1,5 @@
 ### 회원가입
-POST http://localhost:4000/auth/signup
+POST http://localhost:3000/auth/signup
 Content-Type: application/json 
 
 {
@@ -7,4 +7,13 @@ Content-Type: application/json
     "password": "Test123@#",
     "confirmPassword": "Test123@#",
     "nickname" : "test12"
+}
+
+### 로그인
+POST http://localhost:3000/auth/login
+Content-Type: application/json 
+
+{
+    "email": "test33@example.com",
+    "password": "Test123@#"
 }


### PR DESCRIPTION
## 로그인 기능 구현 (auth-login-api)

### 주요 작업 내용
- 로그인 요청 처리 (POST /auth/login)
- 사용자 이메일 존재 여부 확인
- 비밀번호 일치 여부 검증 (`bcrypt.compare`)
- Access / Refresh Token 발급 및 쿠키 저장
- 유효성 검증 스키마 (`loginSchema`) 적용
- 로그인 응답 시 사용자 정보 반환 (id, nickname, points)

### 테스트 방법
- Postman으로 로그인 요청 테스트
- 올바른 계정으로 로그인 시 200 응답 + 토큰 발급 확인
- 틀린 이메일/비밀번호 조합 시 적절한 에러 응답 확인
- 응답에 민감한 정보 제외 (email, password 등)

### 기타
- accessToken: 1시간 유효
- refreshToken: 7일 유효
- 쿠키 설정: `HttpOnly`, `Secure`, `SameSite=None`