### PR TITLE
feat: auth-logout-api 구현

### DIFF
--- a/src/common/middleware/verifyAccessToken.js
+++ b/src/common/middleware/verifyAccessToken.js
@@ -1,0 +1,29 @@
+import { verifyToken } from '../utils/jwt.js';
+
+export const verifyAccessToken = (req, res, next) => {
+  try {
+    const { accessToken } = req.cookies;
+    if (!accessToken) {
+      throw new Error('accessToken이 존재하지 않습니다.');
+    }
+
+    const decoded = verifyToken(accessToken);
+
+    req.user = {
+      id: decoded.id,
+      nickname: decoded.nickname,
+    };
+
+    next();
+  } catch (error) {
+    if (error.name === 'TokenExpiredError') {
+      return res.status(401).json({ message: 'accessToken이 만료되었습니다.' });
+    }
+
+    if (error.name === 'JsonWebTokenError') {
+      return res.status(401).json({ message: '유효하지 않은 accessToken입니다.' });
+    }
+
+    res.status(401).json({ message: error.message || 'accessToken 오류' });
+  }
+};

--- a/src/common/middleware/verifyRefreshToken.js
+++ b/src/common/middleware/verifyRefreshToken.js
@@ -1,0 +1,22 @@
+import { verifyToken } from '../utils/jwt.js';
+
+export const verifyRefreshToken = (req, res, next) => {
+  const { refreshToken } = req.cookies;
+
+  if (!refreshToken) {
+    return res.status(401).json({ message: 'refreshToken이 존재하지 않습니다.' });
+  }
+
+  try {
+    const decoded = verifyToken(refreshToken);
+    req.user = { id: decoded.id };
+    next();
+  } catch (error) {
+    const message =
+      error.name === 'TokenExpiredError'
+        ? 'refreshToken이 만료되었습니다.'
+        : '유효하지 않은 refreshToken입니다.';
+
+    res.status(401).json({ message });
+  }
+};

--- a/src/modules/auth/controller.js
+++ b/src/modules/auth/controller.js
@@ -40,6 +40,24 @@ class AuthController {
       next(error);
     }
   };
+
+  logout = async (req, res, next) => {
+    res.clearCookie('accessToken', {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'none',
+      secure: true,
+    });
+
+    res.clearCookie('refreshToken', {
+      path: '/auth/refresh',
+      httpOnly: true,
+      sameSite: 'none',
+      secure: true,
+    });
+
+    return res.status(200).json({ message: '로그아웃 완료' });
+  };
 }
 
 export default AuthController;

--- a/src/modules/auth/routes.js
+++ b/src/modules/auth/routes.js
@@ -5,6 +5,8 @@ import AuthRepository from './repository.js';
 import { validate } from '../../common/middleware/validate.js';
 import { signupSchema } from './schema/signupSchema.js';
 import { loginSchema } from './schema/loginSchema.js';
+import { verifyAccessToken } from '../../common/middleware/verifyAccessToken.js';
+
 const authRouter = Router();
 
 const authRepository = new AuthRepository();
@@ -13,5 +15,6 @@ const authController = new AuthController(authService);
 
 authRouter.post('/signup', validate(signupSchema, 'body'), authController.signup);
 authRouter.post('/login', validate(loginSchema, 'body'), authController.login);
+authRouter.post('/logout', verifyAccessToken, authController.logout);
 
 export default authRouter;

--- a/test.http
+++ b/test.http
@@ -17,3 +17,9 @@ Content-Type: application/json
     "email": "test33@example.com",
     "password": "Test123@#"
 }
+
+### 로그아웃
+POST http://localhost:3000/auth/logout
+Cookie: accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6OSwibmlja25hbWUiOiJ0ZXN0MTIiLCJpYXQiOjE3NTM5NzA4MDksImV4cCI6MTc1Mzk3NDQwOX0.VRZv7G_hZdScTZCI7daQ1ozpaCeaYQZrmDvc26yPiY8; refreshToken=refreshToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6OSwiaWF0IjoxNzUzOTcwODA5LCJleHAiOjE3NTQ1NzU2MDl9.ej15xR70duk8fWgBEFfT3gPFMf01oM0T4qCH1M7nkxk;
+
+Content-Type: application/json


### PR DESCRIPTION
## 작업 개요
로그아웃 API 구현

## 작업 상세
POST /auth/logout 엔드포인트 생성

accessToken, refreshToken 쿠키 삭제 처리

res.clearCookie() 사용

verifyAccessToken 미들웨어 적용하여 accessToken 인증 필요

## 테스트 방법
로그인 후 /auth/logout 요청

응답에서 Set-Cookie 확인 → 쿠키 제거됨

이후 보호된 API 접근 시 토큰 없음으로 401 확인 가능