### PR TITLE
Fix/seed data consistency

### DIFF
--- a/prisma/data/photoCard.js
+++ b/prisma/data/photoCard.js
@@ -7,7 +7,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 8000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=10',
+    imageUrl:
+      'https://images.unsplash.com/photo-1730396384575-6cefbf4380f9?q=80&w=735&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 11,
@@ -17,7 +18,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 22000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=11',
+    imageUrl:
+      'https://images.unsplash.com/photo-1753925364019-0fa40a7eac5a?q=80&w=2127&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 14,
@@ -27,7 +29,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 12000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=13',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941284-09ee2d6a619c?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 4,
@@ -37,7 +40,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 10000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=15',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750848299202-a95856df3be7?q=80&w=1171&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 20,
@@ -47,7 +51,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 26000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=8',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941037-b3cbfde22acb?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 7,
@@ -57,7 +62,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 27000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=14',
+    imageUrl:
+      'https://images.unsplash.com/photo-1741282198587-65bf77e6075d?q=80&w=1091&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 15,
@@ -67,7 +73,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 12000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=5',
+    imageUrl:
+      'https://images.unsplash.com/photo-1747926836633-e45cc5193310?q=80&w=1147&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 20,
@@ -77,7 +84,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 17000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=1',
+    imageUrl:
+      'https://images.unsplash.com/photo-1738316849598-8cbe1e5ca3f6?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDU0NHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 13,
@@ -87,7 +95,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 8000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=18',
+    imageUrl:
+      'https://images.unsplash.com/photo-1746990263194-0e2826fed608?q=80&w=1172&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 14,
@@ -97,7 +106,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 21000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=2',
+    imageUrl:
+      'https://images.unsplash.com/photo-1742403949587-42a767b9ea5b?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 10,
@@ -107,7 +117,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 29000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=14',
+    imageUrl:
+      'https://images.unsplash.com/photo-1741282198587-65bf77e6075d?q=80&w=1091&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 2,
@@ -117,7 +128,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 17000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=16',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941284-09ee2d6a619c?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 13,
@@ -127,7 +139,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 8000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=7',
+    imageUrl:
+      'https://images.unsplash.com/photo-1744274800188-4f3159c408cf?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 3,
@@ -137,7 +150,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 9000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=13',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750848299202-a95856df3be7?q=80&w=1171&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 9,
@@ -147,7 +161,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 21000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=2',
+    imageUrl:
+      'https://images.unsplash.com/photo-1742403949587-42a767b9ea5b?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 3,
@@ -157,7 +172,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 28000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=8',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941037-b3cbfde22acb?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 10,
@@ -167,7 +183,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 25000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=19',
+    imageUrl:
+      'https://images.unsplash.com/photo-1734688246098-141f0cae5cbf?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ2M3xibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 1,
@@ -177,7 +194,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 18000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=3',
+    imageUrl:
+      'https://images.unsplash.com/photo-1739536176048-caa7190dba66?fm=jpg&q=60&w=3000&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ0MHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 5,
@@ -187,7 +205,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 19000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=6',
+    imageUrl:
+      'https://images.unsplash.com/photo-1738193026612-4a953a4f4e96?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDUzMnxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 10,
@@ -197,7 +216,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 8000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=5',
+    imageUrl:
+      'https://images.unsplash.com/photo-1747926836633-e45cc5193310?q=80&w=1147&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 3,
@@ -207,7 +227,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 24000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=6',
+    imageUrl:
+      'https://images.unsplash.com/photo-1738193026612-4a953a4f4e96?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDUzMnxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 12,
@@ -217,7 +238,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 18000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=11',
+    imageUrl:
+      'https://images.unsplash.com/photo-1753925364019-0fa40a7eac5a?q=80&w=2127&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 15,
@@ -227,7 +249,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 20000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=7',
+    imageUrl:
+      'https://images.unsplash.com/photo-1744274800188-4f3159c408cf?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 13,
@@ -237,7 +260,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 21000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=1',
+    imageUrl:
+      'https://images.unsplash.com/photo-1738316849598-8cbe1e5ca3f6?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDU0NHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 3,
@@ -247,7 +271,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 11000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=3',
+    imageUrl:
+      'https://images.unsplash.com/photo-1739536176048-caa7190dba66?fm=jpg&q=60&w=3000&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ0MHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 11,
@@ -257,7 +282,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 20000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=11',
+    imageUrl:
+      'https://images.unsplash.com/photo-1753925364019-0fa40a7eac5a?q=80&w=2127&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 14,
@@ -267,7 +293,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 20000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=18',
+    imageUrl:
+      'https://images.unsplash.com/photo-1746990263194-0e2826fed608?q=80&w=1172&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 7,
@@ -277,7 +304,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 20000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=0',
+    imageUrl:
+      'https://images.unsplash.com/photo-1626208655973-78ae68dbbc30?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 2,
@@ -287,7 +315,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 28000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=15',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750848299202-a95856df3be7?q=80&w=1171&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 18,
@@ -297,7 +326,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 15000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=9',
+    imageUrl:
+      'https://images.unsplash.com/photo-1743527173859-2cf44e80cef8?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 17,
@@ -307,7 +337,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 12000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=5',
+    imageUrl:
+      'https://images.unsplash.com/photo-1747926836633-e45cc5193310?q=80&w=1147&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 3,
@@ -317,7 +348,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 11000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=10',
+    imageUrl:
+      'https://images.unsplash.com/photo-1730396384575-6cefbf4380f9?q=80&w=735&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 13,
@@ -327,7 +359,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 27000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=9',
+    imageUrl:
+      'https://images.unsplash.com/photo-1743527173859-2cf44e80cef8?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 1,
@@ -337,7 +370,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 26000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=18',
+    imageUrl:
+      'https://images.unsplash.com/photo-1746990263194-0e2826fed608?q=80&w=1172&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 11,
@@ -347,7 +381,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 12000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=13',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750848299202-a95856df3be7?q=80&w=1171&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 19,
@@ -357,7 +392,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 18000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=15',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750848299202-a95856df3be7?q=80&w=1171&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 6,
@@ -367,7 +403,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 22000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=8',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941037-b3cbfde22acb?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 1,
@@ -377,7 +414,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 7000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=8',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941037-b3cbfde22acb?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 20,
@@ -387,7 +425,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 9000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=5',
+    imageUrl:
+      'https://images.unsplash.com/photo-1747926836633-e45cc5193310?q=80&w=1147&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 7,
@@ -397,7 +436,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 18000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=16',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941284-09ee2d6a619c?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 12,
@@ -407,7 +447,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 11000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=8',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941037-b3cbfde22acb?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 15,
@@ -417,7 +458,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 23000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=7',
+    imageUrl:
+      'https://images.unsplash.com/photo-1744274800188-4f3159c408cf?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 13,
@@ -427,7 +469,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 27000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=1',
+    imageUrl:
+      'https://images.unsplash.com/photo-1738316849598-8cbe1e5ca3f6?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDU0NHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 2,
@@ -437,7 +480,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 19000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=9',
+    imageUrl:
+      'https://images.unsplash.com/photo-1743527173859-2cf44e80cef8?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 13,
@@ -447,7 +491,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 22000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=5',
+    imageUrl:
+      'https://images.unsplash.com/photo-1747926836633-e45cc5193310?q=80&w=1147&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 6,
@@ -457,7 +502,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 27000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=7',
+    imageUrl:
+      'https://images.unsplash.com/photo-1744274800188-4f3159c408cf?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 18,
@@ -467,7 +513,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 23000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=7',
+    imageUrl:
+      'https://images.unsplash.com/photo-1744274800188-4f3159c408cf?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 5,
@@ -477,7 +524,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 13000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=16',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941284-09ee2d6a619c?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 9,
@@ -487,7 +535,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 17000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=15',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750848299202-a95856df3be7?q=80&w=1171&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 17,
@@ -497,7 +546,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 15000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=2',
+    imageUrl:
+      'https://images.unsplash.com/photo-1742403949587-42a767b9ea5b?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 10,
@@ -507,7 +557,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 7000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=9',
+    imageUrl:
+      'https://images.unsplash.com/photo-1743527173859-2cf44e80cef8?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 9,
@@ -517,7 +568,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 18000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=13',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750848299202-a95856df3be7?q=80&w=1171&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 8,
@@ -527,7 +579,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 18000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=18',
+    imageUrl:
+      'https://images.unsplash.com/photo-1746990263194-0e2826fed608?q=80&w=1172&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 15,
@@ -537,7 +590,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 7000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=3',
+    imageUrl:
+      'https://images.unsplash.com/photo-1739536176048-caa7190dba66?fm=jpg&q=60&w=3000&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ0MHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 17,
@@ -547,7 +601,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 10000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=19',
+    imageUrl:
+      'https://images.unsplash.com/photo-1734688246098-141f0cae5cbf?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ2M3xibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 16,
@@ -557,7 +612,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 23000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=0',
+    imageUrl:
+      'https://images.unsplash.com/photo-1626208655973-78ae68dbbc30?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 8,
@@ -567,7 +623,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 12000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=1',
+    imageUrl:
+      'https://images.unsplash.com/photo-1738316849598-8cbe1e5ca3f6?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDU0NHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 2,
@@ -577,7 +634,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 28000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=13',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750848299202-a95856df3be7?q=80&w=1171&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 20,
@@ -587,7 +645,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 11000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=3',
+    imageUrl:
+      'https://images.unsplash.com/photo-1739536176048-caa7190dba66?fm=jpg&q=60&w=3000&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ0MHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 8,
@@ -597,7 +656,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 17000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=0',
+    imageUrl:
+      'https://images.unsplash.com/photo-1626208655973-78ae68dbbc30?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 15,
@@ -607,7 +667,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 28000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=9',
+    imageUrl:
+      'https://images.unsplash.com/photo-1743527173859-2cf44e80cef8?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 2,
@@ -617,7 +678,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 25000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=11',
+    imageUrl:
+      'https://images.unsplash.com/photo-1753925364019-0fa40a7eac5a?q=80&w=2127&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 6,
@@ -627,7 +689,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 29000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=19',
+    imageUrl:
+      'https://images.unsplash.com/photo-1734688246098-141f0cae5cbf?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ2M3xibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 1,
@@ -637,7 +700,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 13000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=12',
+    imageUrl:
+      'https://images.unsplash.com/photo-1740166260070-4d129541aa52?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ4OHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 7,
@@ -647,7 +711,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 15000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=18',
+    imageUrl:
+      'https://images.unsplash.com/photo-1746990263194-0e2826fed608?q=80&w=1172&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 15,
@@ -657,7 +722,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 13000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=2',
+    imageUrl:
+      'https://images.unsplash.com/photo-1742403949587-42a767b9ea5b?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 7,
@@ -667,7 +733,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 20000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=2',
+    imageUrl:
+      'https://images.unsplash.com/photo-1742403949587-42a767b9ea5b?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 4,
@@ -677,7 +744,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 13000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=7',
+    imageUrl:
+      'https://images.unsplash.com/photo-1744274800188-4f3159c408cf?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 11,
@@ -687,7 +755,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 9000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=9',
+    imageUrl:
+      'https://images.unsplash.com/photo-1743527173859-2cf44e80cef8?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 7,
@@ -697,7 +766,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 20000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=17',
+    imageUrl:
+      'https://images.unsplash.com/photo-1739869610059-86fabc7bcd7b?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDUwMnxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 9,
@@ -707,7 +777,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 15000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=13',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750848299202-a95856df3be7?q=80&w=1171&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 7,
@@ -717,7 +788,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 25000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=11',
+    imageUrl:
+      'https://images.unsplash.com/photo-1753925364019-0fa40a7eac5a?q=80&w=2127&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 5,
@@ -727,7 +799,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 13000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=19',
+    imageUrl:
+      'https://images.unsplash.com/photo-1734688246098-141f0cae5cbf?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ2M3xibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 9,
@@ -737,7 +810,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 12000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=14',
+    imageUrl:
+      'https://images.unsplash.com/photo-1741282198587-65bf77e6075d?q=80&w=1091&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 16,
@@ -747,7 +821,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 28000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=4',
+    imageUrl:
+      'https://images.unsplash.com/photo-1739361133037-77be66a4ea6a?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDUyMHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 16,
@@ -757,7 +832,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 20000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=11',
+    imageUrl:
+      'https://images.unsplash.com/photo-1753925364019-0fa40a7eac5a?q=80&w=2127&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 4,
@@ -767,7 +843,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 15000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=14',
+    imageUrl:
+      'https://images.unsplash.com/photo-1741282198587-65bf77e6075d?q=80&w=1091&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 13,
@@ -777,7 +854,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 29000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=6',
+    imageUrl:
+      'https://images.unsplash.com/photo-1738193026612-4a953a4f4e96?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDUzMnxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 5,
@@ -787,7 +865,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 12000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=1',
+    imageUrl:
+      'https://images.unsplash.com/photo-1738316849598-8cbe1e5ca3f6?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDU0NHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 13,
@@ -797,7 +876,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 25000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=4',
+    imageUrl:
+      'https://images.unsplash.com/photo-1739361133037-77be66a4ea6a?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDUyMHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 18,
@@ -807,7 +887,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 22000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=10',
+    imageUrl:
+      'https://images.unsplash.com/photo-1730396384575-6cefbf4380f9?q=80&w=735&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 2,
@@ -817,7 +898,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 14000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=12',
+    imageUrl:
+      'https://images.unsplash.com/photo-1740166260070-4d129541aa52?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ4OHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 8,
@@ -827,7 +909,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 25000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=13',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750848299202-a95856df3be7?q=80&w=1171&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 6,
@@ -837,7 +920,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 10000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=2',
+    imageUrl:
+      'https://images.unsplash.com/photo-1742403949587-42a767b9ea5b?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 2,
@@ -847,7 +931,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 17000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=3',
+    imageUrl:
+      'https://images.unsplash.com/photo-1739536176048-caa7190dba66?fm=jpg&q=60&w=3000&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ0MHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 4,
@@ -857,7 +942,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 21000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=5',
+    imageUrl:
+      'https://images.unsplash.com/photo-1747926836633-e45cc5193310?q=80&w=1147&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 9,
@@ -867,7 +953,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 25000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=8',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941037-b3cbfde22acb?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 17,
@@ -877,7 +964,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 17000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=0',
+    imageUrl:
+      'https://images.unsplash.com/photo-1626208655973-78ae68dbbc30?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 20,
@@ -887,7 +975,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 28000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=8',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941037-b3cbfde22acb?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 20,
@@ -897,7 +986,8 @@ export const photoCardData = [
     grade: 'COMMON',
     initialPrice: 23000,
     totalQuantity: 2,
-    imageUrl: 'https://picsum.photos/360/270?random=18',
+    imageUrl:
+      'https://images.unsplash.com/photo-1746990263194-0e2826fed608?q=80&w=1172&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 4,
@@ -907,7 +997,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 10000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=14',
+    imageUrl:
+      'https://images.unsplash.com/photo-1741282198587-65bf77e6075d?q=80&w=1091&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 15,
@@ -917,7 +1008,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 29000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=9',
+    imageUrl:
+      'https://images.unsplash.com/photo-1743527173859-2cf44e80cef8?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 8,
@@ -927,7 +1019,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 11000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=8',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941037-b3cbfde22acb?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 18,
@@ -937,7 +1030,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 19000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=3',
+    imageUrl:
+      'https://images.unsplash.com/photo-1739536176048-caa7190dba66?fm=jpg&q=60&w=3000&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDQ0MHxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 9,
@@ -947,7 +1041,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 23000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=17',
+    imageUrl:
+      'https://images.unsplash.com/photo-1739869610059-86fabc7bcd7b?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDUwMnxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
   {
     creatorId: 10,
@@ -957,7 +1052,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 25000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=16',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941284-09ee2d6a619c?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 12,
@@ -967,7 +1063,8 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 29000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=16',
+    imageUrl:
+      'https://images.unsplash.com/photo-1750779941284-09ee2d6a619c?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 15,
@@ -977,7 +1074,8 @@ export const photoCardData = [
     grade: 'LEGENDARY',
     initialPrice: 26000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=11',
+    imageUrl:
+      'https://images.unsplash.com/photo-1753925364019-0fa40a7eac5a?q=80&w=2127&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 7,
@@ -987,7 +1085,8 @@ export const photoCardData = [
     grade: 'SUPER_RARE',
     initialPrice: 26000,
     totalQuantity: 3,
-    imageUrl: 'https://picsum.photos/360/270?random=14',
+    imageUrl:
+      'https://images.unsplash.com/photo-1741282198587-65bf77e6075d?q=80&w=1091&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
     creatorId: 14,
@@ -997,6 +1096,7 @@ export const photoCardData = [
     grade: 'RARE',
     initialPrice: 10000,
     totalQuantity: 1,
-    imageUrl: 'https://picsum.photos/360/270?random=17',
+    imageUrl:
+      'https://images.unsplash.com/photo-1739869610059-86fabc7bcd7b?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDUwMnxibzhqUUtUYUUwWXx8ZW58MHx8fHx8',
   },
 ];

--- a/prisma/migrations/20250804133940_update_sale/migration.sql
+++ b/prisma/migrations/20250804133940_update_sale/migration.sql
@@ -1,0 +1,48 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `status` on the `Sale` table. All the data in the column will be lost.
+  - You are about to drop the column `userCardId` on the `Sale` table. All the data in the column will be lost.
+  - You are about to drop the column `isOnSale` on the `UserCard` table. All the data in the column will be lost.
+  - Added the required column `message` to the `ExchangeProposal` table without a default value. This is not possible if the table is not empty.
+  - Made the column `description` on table `PhotoCard` required. This step will fail if there are existing NULL values in that column.
+  - Added the required column `type` to the `Purchase` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userCardId` to the `Purchase` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `initialQuantity` to the `Sale` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `quantity` to the `Sale` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "UserCardStatus" AS ENUM ('IDLE', 'ON_SALE', 'PROPOSED');
+
+-- CreateEnum
+CREATE TYPE "PurchaseType" AS ENUM ('POINT', 'EXCHANGE');
+
+-- DropForeignKey
+ALTER TABLE "Sale" DROP CONSTRAINT "Sale_userCardId_fkey";
+
+-- AlterTable
+ALTER TABLE "ExchangeProposal" ADD COLUMN     "message" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "PhotoCard" ALTER COLUMN "description" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Purchase" ADD COLUMN     "type" "PurchaseType" NOT NULL,
+ADD COLUMN     "userCardId" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Sale" DROP COLUMN "status",
+DROP COLUMN "userCardId",
+ADD COLUMN     "initialQuantity" INTEGER NOT NULL,
+ADD COLUMN     "quantity" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "UserCard" DROP COLUMN "isOnSale",
+ADD COLUMN     "status" "UserCardStatus" NOT NULL DEFAULT 'IDLE';
+
+-- DropEnum
+DROP TYPE "SaleStatus";
+
+-- AddForeignKey
+ALTER TABLE "Purchase" ADD CONSTRAINT "Purchase_userCardId_fkey" FOREIGN KEY ("userCardId") REFERENCES "UserCard"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,23 +8,23 @@ datasource db {
 }
 
 model User {
-  id                 Int                 @id @default(autoincrement())
-  email              String              @unique
-  nickname           String
-  password           String?
-  provider           AuthProvider        @default(LOCAL)
-  providerId         String?
-  points             Int                 @default(0)
-  createdAt          DateTime            @default(now())
-  updatedAt          DateTime            @updatedAt
-  photoCards         PhotoCard[]         @relation("OwnerCards")
-  ownedCards         UserCard[]          @relation("UserOwnedCards")
-  sales              Sale[]              @relation("SellerSales")
-  purchases          Purchase[]          @relation("BuyerPurchases")
-  proposals          ExchangeProposal[]  @relation("ProposingUser")
-  notifications      Notification[]
-  pointLogs          PointLog[]
-  cardCreationLimits CardCreationLimit[]
+  id                  Int                 @id @default(autoincrement())
+  email               String              @unique
+  nickname            String
+  password            String?
+  provider            AuthProvider        @default(LOCAL)
+  providerId          String?
+  points              Int                 @default(0)
+  createdAt           DateTime            @default(now())
+  updatedAt           DateTime            @updatedAt
+  photoCards          PhotoCard[]         @relation("OwnerCards")
+  userCards           UserCard[]          @relation("UserOwnedCards")
+  sales               Sale[]              @relation("SalesBySeller")
+  purchases           Purchase[]          @relation("BuyerPurchases")
+  proposedExchanges   ExchangeProposal[]  @relation("ProposingUser")
+  notifications       Notification[] 
+  pointLogs           PointLog[] 
+  cardCreationLimits  CardCreationLimit[]
 }
 
 enum AuthProvider {
@@ -33,116 +33,112 @@ enum AuthProvider {
 }
 
 model PhotoCard {
-  id            Int        @id @default(autoincrement())
-  name          String
-  description   String?
-  imageUrl      String
-  grade         CardGrade
-  genre         CardGenre
-  initialPrice  Int
-  totalQuantity Int
-  createdAt     DateTime   @default(now())
-  updatedAt     DateTime   @updatedAt
-  creatorId     Int
-  creator       User       @relation("OwnerCards", fields: [creatorId], references: [id])
-  userCards     UserCard[]
-  sales         Sale[]     @relation("PhotoCardToSale")
-}
-
-model UserCard {
-  id                Int                @id @default(autoincrement())
-  isOnSale          Boolean            @default(false)
-  createdAt         DateTime           @default(now())
-  ownerId           Int
-  owner             User               @relation("UserOwnedCards", fields: [ownerId], references: [id])
-  photoCardId       Int
-  photoCard         PhotoCard          @relation(fields: [photoCardId], references: [id])
-  sales             Sale[]
-  exchangeProposals ExchangeProposal[]
-}
-
-model Sale {
-  id           Int                @id @default(autoincrement())
-  sellerId     Int
-  seller       User               @relation("SellerSales", fields: [sellerId], references: [id])
-  userCardId   Int
-  userCard     UserCard           @relation(fields: [userCardId], references: [id])
-  photoCardId  Int
-  photoCard    PhotoCard          @relation("PhotoCardToSale", fields: [photoCardId], references: [id])
-  price        Int
-  status       SaleStatus         @default(ON_SALE)
-  desiredGrade CardGrade?
-  desiredGenre CardGenre?
-  desiredDesc  String?
-  createdAt    DateTime           @default(now())
-  updatedAt    DateTime           @updatedAt
-  proposals    ExchangeProposal[]
-  purchases    Purchase[]
-}
-
-// ⚠️ Prisma에서는 View를 테이블처럼 인식하지 않기 때문에 주의가 필요함
-// 1. `@@ignore`를 추가한 상태에서 `prisma migrate`를 실행해야 migration 충돌이 없음
-// 2. 이후 `@@ignore`를 제거하고 `npx prisma generate`를 실행해야 client에서 view에 접근 가능함
-//
-// - migration = @@ignore O
-// - generate  = @@ignore X
-model SaleMarketSummary {
-  photoCardId     Int
-  price           Int
-  sellerId        Int
-  nickname        String
-  totalRegistered Int
-  totalOnSale     Int
-  createdAt       DateTime
+  id              Int        @id @default(autoincrement())
   name            String
+  description     String
   imageUrl        String
   grade           CardGrade
   genre           CardGenre
+  initialPrice    Int
+  // 유저가 포토카드 생성 시 설정한 총 발행량 (변경되지 않음)
+  totalQuantity   Int
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
   creatorId       Int
-
-  @@id([photoCardId, sellerId])
-  @@map("sale_market_summary") // 실제 뷰 이름
+  creator         User       @relation("OwnerCards", fields: [creatorId], references: [id])
+  userCards       UserCard[]
+  sales           Sale[]     @relation("SalesForPhotoCard")
 }
 
+model UserCard {
+  id                Int               @id @default(autoincrement())
+  // 개별 카드의 거래 상태를 나타내기 위한 데이터
+  status            UserCardStatus    @default(IDLE) 
+  createdAt         DateTime          @default(now())
+  ownerId           Int
+  owner             User              @relation("UserOwnedCards", fields: [ownerId], references: [id])
+  photoCardId       Int
+  photoCard         PhotoCard         @relation(fields: [photoCardId], references: [id])
+  purchases         Purchase[] 
+  exchangeProposals ExchangeProposal[]
+}
+
+enum UserCardStatus {
+  IDLE         
+  ON_SALE      
+  PROPOSED     
+}
+
+model Sale {
+  id               Int               @id @default(autoincrement())
+  sellerId         Int
+  seller           User              @relation("SalesBySeller", fields: [sellerId], references: [id])
+  photoCardId      Int
+  photoCard        PhotoCard         @relation("SalesForPhotoCard", fields: [photoCardId], references: [id])
+  price            Int
+  // 판매 등록 시 올린 카드 수량입니다 (ex. 5장 중 3장 판매 등록 → 3)
+  initialQuantity  Int 
+   // 거래가 발생할 때마다 감소하며, 남은 수량을 나타냅니다.
+  quantity         Int             
+  desiredGrade     CardGrade?
+  desiredGenre     CardGenre?
+  desiredDesc      String?
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt
+  proposals        ExchangeProposal[]
+  purchases        Purchase[]
+}
+
+// 포인트 구매 또는 카드 교환 거래의 이력을 저장하는 테이블입니다.
+// 거래를 통해 userCard의 소유권이 변경된 내역을 기록합니다.
 model Purchase {
-  id        Int      @id @default(autoincrement())
-  buyer     User     @relation("BuyerPurchases", fields: [buyerId], references: [id])
-  buyerId   Int
-  sale      Sale     @relation(fields: [saleId], references: [id])
-  saleId    Int
-  createdAt DateTime @default(now())
+  id         Int           @id @default(autoincrement())
+  buyer      User          @relation("BuyerPurchases", fields: [buyerId], references: [id])
+  buyerId    Int
+  sale       Sale          @relation(fields: [saleId], references: [id])
+  saleId     Int
+  userCard   UserCard      @relation(fields: [userCardId], references: [id])
+  userCardId Int
+  type       PurchaseType  
+  createdAt  DateTime      @default(now())
+}
+
+enum PurchaseType {
+  POINT
+  EXCHANGE
 }
 
 model ExchangeProposal {
-  id             Int            @id @default(autoincrement())
-  saleId         Int
-  sale           Sale           @relation(fields: [saleId], references: [id])
-  proposedCardId Int
-  proposedCard   UserCard       @relation(fields: [proposedCardId], references: [id])
-  proposerId     Int
-  proposer       User           @relation("ProposingUser", fields: [proposerId], references: [id])
-  status         ProposalStatus @default(PENDING)
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
+  id              Int             @id @default(autoincrement())
+  saleId          Int
+  sale            Sale            @relation(fields: [saleId], references: [id])
+  proposedCardId  Int
+  proposedCard    UserCard        @relation(fields: [proposedCardId], references: [id])
+  proposerId      Int
+  proposer        User            @relation("ProposingUser", fields: [proposerId], references: [id])
+  message         String
+  status          ProposalStatus  @default(PENDING)
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
 }
 
 model Notification {
-  id        Int              @id @default(autoincrement())
-  user      User             @relation(fields: [userId], references: [id])
-  userId    Int
-  content   String
-  type      NotificationType
-  createdAt DateTime         @default(now())
-  read      Boolean          @default(false)
+  id          Int               @id @default(autoincrement())
+  user        User              @relation(fields: [userId], references: [id])
+  userId      Int
+  content     String
+  type        NotificationType
+  createdAt   DateTime          @default(now())
+  read        Boolean           @default(false)
 }
 
 model PointLog {
-  id        Int      @id @default(autoincrement())
-  user      User     @relation(fields: [userId], references: [id])
-  userId    Int
-  amount    Int
-  reason    String
-  createdAt DateTime @default(now())
+  id          Int               @id @default(autoincrement())
+  user        User              @relation(fields: [userId], references: [id])
+  userId      Int
+  amount      Int
+  reason      String
+  createdAt   DateTime          @default(now())
 }
 
 model CardCreationLimit {
@@ -165,13 +161,6 @@ enum CardGrade {
   LEGENDARY
 }
 
-// NOTE: 현재 CardGenre ENUM은 제공되는 시딩데이터 장르 기준으로 정의
-// 서비스 요구사항에 따라 장르 항목을 변경하거나 추가할 경우,
-// 아래 두 항목을 반드시 함께 수정해야 합니다:
-// - Prisma 스키마 파일 (schema.prisma)
-// - Zod 스키마 정의 (예: getSaleListSchema 등)
-//
-// 이 두 정의가 불일치할 경우, 데이터 검증 오류 또는 런타임 에러가 발생할 수 있습니다.
 enum CardGenre {
   ALBUM
   SPECIAL
@@ -183,11 +172,6 @@ enum CardGenre {
   COLLAB
   FANCLUB
   ETC
-}
-
-enum SaleStatus {
-  ON_SALE
-  SOLD_OUT
 }
 
 enum ProposalStatus {

--- a/prisma/seeds/seed-sale.js
+++ b/prisma/seeds/seed-sale.js
@@ -1,40 +1,56 @@
 import { prisma } from '../../src/common/utils/prisma.js';
+import { CardGrade, CardGenre, UserCardStatus } from '@prisma/client';
 
-export default async function seedSale(userIdMap, photoCardIdMap, userCardIdMap) {
-  const targetSales = [];
+// 랜덤 Enum 값 가져오기
+function getRandomEnumValue(enumeration) {
+  const values = Object.values(enumeration);
+  const index = Math.floor(Math.random() * values.length);
+  return values[index];
+}
 
-  for (const [index, userCardId] of userCardIdMap.entries()) {
-    if (index % 2 !== 0) continue;
+export default async function seedSale() {
+  const allPhotoCards = await prisma.photoCard.findMany({
+    include: {
+      userCards: true,
+    },
+  });
 
-    const userCard = await prisma.userCard.findUnique({
-      where: { id: userCardId },
+  for (let i = 0; i < allPhotoCards.length; i++) {
+    if ((i + 1) % 2 !== 0) continue; // 짝수만
+
+    const photoCard = allPhotoCards[i];
+    const idleCards = photoCard.userCards.filter(
+      (uc) => uc.ownerId === photoCard.creatorId && uc.status === 'IDLE'
+    );
+
+    if (idleCards.length === 0) continue; // 올릴 거 없음
+
+    const saleQuantity = Math.min(2, idleCards.length);
+    const desiredGrade = getRandomEnumValue(CardGrade);
+    const desiredGenre = getRandomEnumValue(CardGenre);
+    const desiredDesc = `${desiredGenre} 장르의 카드 중 ${desiredGrade} 등급이랑 교환 희망합니다`;
+
+    const sale = await prisma.sale.create({
+      data: {
+        sellerId: photoCard.creatorId,
+        photoCardId: photoCard.id,
+        price: photoCard.initialPrice,
+        initialQuantity: saleQuantity,
+        quantity: saleQuantity,
+        desiredGrade,
+        desiredGenre,
+        desiredDesc,
+      },
     });
 
-    if (!userCard) {
-      throw new Error(
-        `userCard with id ${userCardId} not found. Check your userCardIdMap or previous seeding logic.`
-      );
+    const toUpdate = idleCards.slice(0, saleQuantity);
+    for (const userCard of toUpdate) {
+      await prisma.userCard.update({
+        where: { id: userCard.id },
+        data: { status: UserCardStatus.ON_SALE },
+      });
     }
-
-    await prisma.userCard.update({
-      where: { id: userCardId },
-      data: { isOnSale: true },
-    });
-
-    targetSales.push({
-      sellerId: userCard.ownerId,
-      userCardId,
-      photoCardId: userCard.photoCardId,
-      price: 1500,
-      desiredGrade: 'COMMON',
-      desiredGenre: 'CONCERT',
-      status: 'ON_SALE',
-    });
   }
 
-  if (targetSales.length === 0) {
-    throw new Error('No sales were generated. Check your logic.');
-  }
-
-  await prisma.sale.createMany({ data: targetSales });
+  console.log('[seed-sale] 판매 등록 완료됨');
 }


### PR DESCRIPTION

# 작업 개요
포토카드 중심의 거래 구조 반영을 위한 스키마 리팩토링 및 시딩 로직 정비
UI 상에서 거래가 userCard 단위가 아닌 photoCard 단위로 이뤄지는 점을 고려해, 기존 스키마 및 시딩 로직을 전면적으로 개선

### 기존 문제점
거래 단위 불일치
- 기존에는 UserCard 기준으로 거래가 구성되어 있었으나, 실제 프론트 UI는 PhotoCard 기준으로 거래를 진행함 → 구조 불일치
시딩 코드 불일치 및 오류
- 변경된 구조에 맞지 않는 seed-sale.js로 인해 시딩 실패 발생
랜덤 이미지 URL 사용
- photoCard.imageUrl에 랜덤 이미지 URL을 사용함에 따라, 프론트에서 Next.js의 prefetch 기능을 테스트하기 어려움

### 작업 상세
Sale 스키마 변경
- 거래 기준을 UserCard → PhotoCard로 변경
- 그에 따라 연관된 ExchangeProposal, Purchase 등 모델 관계 재정의
연쇄 스키마 정비
- UserCard, Sale, ExchangeProposal, Purchase 등 상호 참조 관계 조정

시딩 스크립트(sale) 전면 수정
- 조건: photoCardId가 짝수인 경우에만 Sale 등록
- 수량은 최대 2장까지만 등록 (단, 보유한 UserCard 수가 부족한 경우 자동 조정)
- 등록된 UserCard는 ON_SALE 상태로 변경
- 교환 희망 정보(desiredGrade, desiredGenre, desiredDesc)는 랜덤 생성

이미지 URL 고정값으로 교체
- 테스트 환경에서의 prefetch 오류를 방지하기 위해 photoCard.imageUrl을 랜덤 URL → 고정 URL로 일괄 수정

### 통합 및 정리된 파일 목록
수정된 시딩 파일
- prisma/seeds/seed-sale.js
