### PR TITLE
refactor/get sale list api #10

### DIFF
--- a/src/modules/sale/controller.js
+++ b/src/modules/sale/controller.js
@@ -5,7 +5,7 @@ class SaleController {
 
   getSaleList = async (req, res, next) => {
     try {
-      console.log('컨트롤러에서 req.query: ', req.query);
+      // console.log('컨트롤러에서 req.query: ', req.query);
       const query = req.query;
       const saleList = await this.saleService.getSaleList(query);
       return res.status(200).json(saleList);

--- a/src/modules/sale/repository.js
+++ b/src/modules/sale/repository.js
@@ -1,36 +1,21 @@
 import { prisma } from '../../common/utils/prisma.js';
 
 class SaleRepository {
-  async getSaleListAndTotalCount({ where, orderByClause, skip, take }) {
-    const [saleList, totalCount] = await Promise.all([
-      prisma.sale.findMany({
-        where,
-        orderBy: orderByClause || { createdAt: 'desc' },
-        skip,
-        take,
-        include: {
-          photoCard: {
-            select: {
-              id: true,
-              name: true,
-              description: true,
-              imageUrl: true,
-              grade: true,
-              genre: true,
-            },
-          },
-          seller: {
-            select: {
-              nickname: true,
-            },
-          },
-        },
-      }),
-      prisma.sale.count({ where }),
-    ]);
+  getSaleList = async ({ where, orderByClause, include, skip, take }) => {
+    const sales = await prisma.sale.findMany({
+      where,
+      orderBy: orderByClause || { createdAt: 'desc' },
+      skip,
+      take,
+      include,
+    });
+    return sales;
+  };
 
-    return { saleList, totalCount };
-  }
+  getTotalCount = async ({ where }) => {
+    const totalCount = await prisma.sale.count({ where });
+    return totalCount;
+  };
 }
 
 export default SaleRepository;

--- a/src/modules/sale/service.js
+++ b/src/modules/sale/service.js
@@ -38,6 +38,7 @@ class SaleService {
         },
       ],
     };
+
     const orderByClause = {
       priceLowToHigh: { price: 'asc' },
       priceHighToLow: { price: 'desc' },
@@ -45,15 +46,29 @@ class SaleService {
       oldest: { createdAt: 'asc' },
     }[orderBy];
 
-    const { saleList, totalCount } = await this.saleRepository.getSaleListAndTotalCount({
-      where,
-      orderByClause,
-      skip,
-      take,
-    });
+    const include = {
+      photoCard: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          imageUrl: true,
+          grade: true,
+          genre: true,
+        },
+      },
+      seller: {
+        select: { nickname: true },
+      },
+    };
 
-    console.log('saleList: ', saleList);
-    console.log('totalCount: ', totalCount);
+    const [saleList, totalCount] = await Promise.all([
+      this.saleRepository.getSaleList({ where, orderByClause, include, skip, take }),
+      this.saleRepository.getTotalCount({ where }),
+    ]);
+
+    // console.log('saleList: ', saleList);
+    // console.log('totalCount: ', totalCount);
 
     const formattedSales = saleList.map((sale) => ({
       saleId: sale.id,

--- a/test.http
+++ b/test.http
@@ -34,5 +34,5 @@ Cookie: accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjEsIm5pY2tuYW1
 Content-Type: application/json
 
 ### 판매 목록 조회
-GET http://localhost:3000/sales?includeSoldOut=false
+GET http://localhost:3000/sales?pageSize=1&includeSoldOut=false
 Content-Type: application/json


### PR DESCRIPTION
###작업내용
- 기존 :  get-sale-list-api는 레포지토리에서 getSaleListAndTotalCount메서드 안에서 promise all로 묶어서 처리하고 있었다.
- 변경 : 레포의 getSaleListAndTotalCount메서드를 getSaleList와 getTotalCount메서드로 분리하여 서비스단에서 Promise all 처리하도록 수정
